### PR TITLE
Add gmsh generated mesh 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.h5
+*.xdmf
+*.xml
+Results
+**/__pycache__/**

--- a/mesh_generator.py
+++ b/mesh_generator.py
@@ -1,0 +1,100 @@
+import gmsh
+from mpi4py import MPI
+
+gmsh.initialize()
+import numpy as np
+
+L = 5
+H = 5
+c_x = c_y = 0
+r = 1
+fluid_marker = 1
+res_min = r / 3
+order = 1
+gdim = 2
+mesh_comm = MPI.COMM_WORLD
+model_rank = 0
+if mesh_comm.rank == model_rank:
+    rectangle = gmsh.model.occ.addRectangle(-L / 2, -H / 2, 0, L, H, tag=1)
+    obstacle = gmsh.model.occ.addDisk(c_x, c_y, 0, r, r)
+
+    fluid = gmsh.model.occ.cut([(gdim, rectangle)], [(gdim, obstacle)])
+    gmsh.model.occ.synchronize()
+    volumes = gmsh.model.getEntities(dim=gdim)
+    assert len(volumes) == 1
+    gmsh.model.addPhysicalGroup(volumes[0][0], [volumes[0][1]], fluid_marker)
+    gmsh.model.setPhysicalName(volumes[0][0], fluid_marker, "Fluid")
+
+
+# inlet_marker, outlet_marker = 3, 3
+wall_marker, obstacle_marker = 3, 1
+
+
+inflow, outflow, walls, obstacle = [], [], [], []
+if mesh_comm.rank == model_rank:
+    boundaries = gmsh.model.getBoundary(volumes, oriented=False)
+    for boundary in boundaries:
+        center_of_mass = gmsh.model.occ.getCenterOfMass(boundary[0], boundary[1])
+        if np.allclose(center_of_mass, [0, -L / 2, 0]):
+            inflow.append(boundary[1])
+        elif np.allclose(center_of_mass, [0, L / 2, 0]):
+            outflow.append(boundary[1])
+        elif np.allclose(center_of_mass, [-L / 2, 0, 0]) or np.allclose(
+            center_of_mass, [L / 2, 0, 0]
+        ):
+            walls.append(boundary[1])
+        else:
+            obstacle.append(boundary[1])
+    walls.extend(inflow)
+    walls.extend(outflow)
+
+    gmsh.model.addPhysicalGroup(1, walls, wall_marker)
+    gmsh.model.setPhysicalName(1, wall_marker, "Walls")
+    # gmsh.model.addPhysicalGroup(1, inflow, inlet_marker)
+    # gmsh.model.setPhysicalName(1, inlet_marker, "Inlet")
+    # gmsh.model.addPhysicalGroup(1, outflow, outlet_marker)
+    # gmsh.model.setPhysicalName(1, outlet_marker, "Outlet")
+    gmsh.model.addPhysicalGroup(1, obstacle, obstacle_marker)
+    gmsh.model.setPhysicalName(1, obstacle_marker, "Obstacle")
+
+    distance_field = gmsh.model.mesh.field.add("Distance")
+    gmsh.model.mesh.field.setNumbers(distance_field, "EdgesList", obstacle)
+    threshold_field = gmsh.model.mesh.field.add("Threshold")
+    gmsh.model.mesh.field.setNumber(threshold_field, "IField", distance_field)
+    gmsh.model.mesh.field.setNumber(threshold_field, "LcMin", res_min)
+    gmsh.model.mesh.field.setNumber(threshold_field, "LcMax", 0.25 * H)
+    gmsh.model.mesh.field.setNumber(threshold_field, "DistMin", r)
+    gmsh.model.mesh.field.setNumber(threshold_field, "DistMax", 2 * H)
+    min_field = gmsh.model.mesh.field.add("Min")
+    gmsh.model.mesh.field.setNumbers(min_field, "FieldsList", [threshold_field])
+    gmsh.model.mesh.field.setAsBackgroundMesh(min_field)
+    # gmsh.option.setNumber("Mesh.Algorithm", 8)
+    # gmsh.option.setNumber("Mesh.RecombinationAlgorithm", 2)
+    # gmsh.option.setNumber("Mesh.RecombineAll", 1)
+    # gmsh.option.setNumber("Mesh.SubdivisionAlgorithm", 1)
+    gmsh.model.mesh.generate(gdim)
+    gmsh.model.mesh.setOrder(order)
+    gmsh.model.mesh.optimize("Netgen")
+    gmsh.write("test.msh")
+
+
+import meshio
+
+in_mesh = meshio.read("test.msh")
+
+
+def create_mesh(mesh, cell_type, prune_z=False):
+    cells = mesh.get_cells_type(cell_type)
+    cell_data = mesh.get_cell_data("gmsh:physical", cell_type)
+    points = mesh.points[:, :2] if prune_z else mesh.points
+    out_mesh = meshio.Mesh(
+        points=points, cells={cell_type: cells}, cell_data={"name_to_read": [cell_data]}
+    )
+    return out_mesh
+
+
+line_mesh = create_mesh(in_mesh, "line", prune_z=True)
+meshio.write("facet_mesh.xdmf", line_mesh)
+
+triangle_mesh = create_mesh(in_mesh, "triangle", prune_z=True)
+meshio.write("mesh.xdmf", triangle_mesh)

--- a/run_convergence_test.py
+++ b/run_convergence_test.py
@@ -38,7 +38,6 @@ def run_convergence_test(N_i, params):
     for i in range(1, N_i):
         new_mesh = adapt(meshes[-1])
         new_mf = adapt(facet_functions[-1], new_mesh)
-        mesh_size_surface
         meshes.append(new_mesh)
         facet_functions.append(new_mf)
         hs.append(meshes[-1].hmax())

--- a/run_convergence_test.py
+++ b/run_convergence_test.py
@@ -101,7 +101,6 @@ def run_convergence_test(N_i, params):
     var_list = [u_a_i, p_a_i, u, p]
     for ix, file in enumerate(file_list):
         file << var_list[ix]
-    from IPython import embed;embed()
     root = Path(code_path)
     xdmf_file_list = [XDMFFile(str(((root / "Results" / "Plots" / var_name).with_suffix(".xdmf")))) for var_name in var_names]
     for file, name, var in zip(xdmf_file_list, var_names, var_list):

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,6 @@
 from fenics import *
 import numpy as np
-import solve as solvers
-
+from pathlib import Path
 def write_convergence_table(error, file_name, variable_name, parameters, gammas, meshes, hs, hgammas):
 
     desc = '_beta'+str(parameters['beta'])
@@ -28,7 +27,8 @@ def write_convergence_table(error, file_name, variable_name, parameters, gammas,
         desc += '_discnormal'
         caption += ', discrete normal'
 
-
+    file_path = Path(file_name+desc)
+    file_path.parent.mkdir(parents=True, exist_ok=True)    
     ffile = open(file_name+desc, "w+")
 
     # Make preamble for table


### PR DESCRIPTION
- Makes code standalone (no mesh needed to be uploaded).
- Can be executed with ` ghcr.io/scientificcomputing/fenics-gmsh:jupterlab-2023-04-21 ` docker images.
[ ] I guess there should be something about this in the readme section.

- I changed the code to use adapt on the coarsest grid to get the finer grids (let me know if this is ok)
- Added XDMF outputting with accurate P-N visualization, see image below for gained accuracy on a coarse grid
![velocity_difference](https://github.com/IngeborgGjerde/nitsche-method-for-navier-stokes-with-slip/assets/8554300/171364ea-8b45-4ce6-977e-b32c50f0dba4)
